### PR TITLE
Fix/xray vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS build
+FROM golang:1.17.5-alpine as builder
 ENV PROJECT grpc_health_probe
 WORKDIR /src/$PROJECT
 COPY go.mod go.sum ./
@@ -6,6 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
-FROM alpine:3.8
-COPY --from=build /go/bin/grpc-health-probe /bin/grpc_health_probe
+FROM scratch
+WORKDIR /
+COPY --from=builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 ENTRYPOINT [ "/bin/grpc_health_probe" ]


### PR DESCRIPTION
- Making the 2nd stage of the multi-stage build use `scratch` instead of `alpine` to reduce image size and attack vectors.
- Bumping to `golang:1.17.5-alpine` for the build image

![image](https://user-images.githubusercontent.com/6247817/148594218-2422803c-1612-4a5c-b090-91e6f32e606e.png)
